### PR TITLE
Adds a pre-commit hook for ggshield not in a CI environment

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: ggshield-not-ci
+  name: GitGuardian Shield (pre-commit)
+  entry: bash -c 'if [[ ! -z ${CI}} ]]; then ggshield secret scan pre-commit; fi'
+  description: Runs ggshield in non-CI environments to detect hardcoded secrets, security vulnerabilities and policy breaks.
+  stages: [commit]
+  language: system

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: ggshield-not-ci
   name: GitGuardian Shield (pre-commit)
-  entry: bash -c 'if [[ ! -z ${CI}} ]]; then ggshield secret scan pre-commit; fi'
   description: Runs ggshield in non-CI environments to detect hardcoded secrets, security vulnerabilities and policy breaks.
   stages: [commit]
-  language: system
+  entry: hooks/ggshield-not-ci.sh
+  language: script

--- a/hooks/ggshield-not-ci.sh
+++ b/hooks/ggshield-not-ci.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+if [[ ! -z "${CI}"} ]]; then
+  ggshield secret scan pre-commit
+fi


### PR DESCRIPTION
## Description & motivation

Would like to run ggshield locally as part of a pre-commit step, but not in a CI environment.  This pre-commit hook does that.

## Changes:
- adds a pre-commit hook `ggshield-not-ci`

## To-do before merge:


## Screenshots:


## Validation of changes:


## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References


