### PR TITLE
fix(ggshield-not-ci): correct logic and print when skipping

### DIFF
--- a/hooks/ggshield-not-ci.sh
+++ b/hooks/ggshield-not-ci.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [[ ! -z "${CI}"} ]]; then
+if [[ -z "${CI}" ]]; then
   ggshield secret scan pre-commit
+else
+  echo "In a CI environment, so skipping GitGuardian ggshield"
 fi


### PR DESCRIPTION
## Description & motivation

Fix broken hook

## Changes:

- fix: logic in ggshield-not-ci hook
- feat: log when skipping because CI

## To-do before merge:



## Screenshots:


## Validation of changes:


## Checklist:


- [x] My pull request follows the guidelines in the [Contributing guide](https://github.com/specklesystems/speckle-server/blob/main/CONTRIBUTING.md)?
- [x] My pull request does not duplicate any other open [Pull Requests](../../pulls) for the same update/change?
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] My code follows a similar style to existing code.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.

## References

